### PR TITLE
Fix docs for garage configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ O PostgreSQL estará disponível na porta 5432 e a aplicação em http://localho
 
 ### Configuração da Garagem
 - `GET /garage` - Obtém a configuração atual da garagem
-- `POST /garage` - Importa nova configuração da garagem
+- *Endpoint `POST /garage` para importar configuracoes ainda nao esta disponivel*
 
 ### Status
 - `POST /plate-status` - Consulta status de uma placa
@@ -192,7 +192,7 @@ A documentação Swagger/OpenAPI está disponível em:
 
 #### Configuração da Garagem
 - `GET /garage` - Obtém configuração da garagem
-- `POST /garage` - Importa configuração da garagem
+- *Endpoint `POST /garage` para importar configuracoes ainda nao esta disponivel*
 
 #### Webhook do Simulador
 - `POST /webhook` - Recebe eventos de entrada/saída/estacionamento


### PR DESCRIPTION
## Summary
- clarify that POST `/garage` is not yet available

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e2d838288321bdf2a9951b9a9ad8