### PR TITLE
Add missing event_type test

### DIFF
--- a/src/test/java/com/estapar/parking/controller/WebhookControllerTest.java
+++ b/src/test/java/com/estapar/parking/controller/WebhookControllerTest.java
@@ -108,6 +108,21 @@ class WebhookControllerTest {
     }
 
     @Test
+    void handleWebhook_WhenEventTypeIsMissing_ShouldReturnBadRequest() throws Exception {
+        // Arrange
+        VehicleEventDTO event = new VehicleEventDTO();
+        event.setLicensePlate("ABC1234");
+
+        // Act & Assert
+        mockMvc.perform(post("/webhook")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(event)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Event cannot be null"));
+    }
+
+    @Test
     void handleWebhook_WhenServiceThrowsException_ShouldReturnInternalServerError() throws Exception {
         // Arrange
         VehicleEventDTO event = new VehicleEventDTO();


### PR DESCRIPTION
## Summary
- add a test that posts a webhook without `event_type`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_6849e2dd73e4832182ece8e3f7aa342f